### PR TITLE
feat: implémenter un tunnel ssh inversé (reverse ssh tunnel) pour Desi

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,37 @@ root/
 
 | Script | Rôle technique | Contexte d'exécution |
 |--------|----------------|----------------------|
+| `setup_reverse_tunnel.sh` | Sets up an `autossh` reverse tunnel to access Desi GPUs | Background Service (PM2) |
 | `diagnose_uv.py` | Validates `uv` based environment handling | Local/Remote |
 | `diagnose_ray_segfault.py` | Diagnoses 3.12.1 Segfaults on Desi | Remote |
 | `check_desi_locks.py` | Inspects lock files on Desi | Local (connects to Remote) |
 | `check_desi_resources.py` | Checks CPU/GPU availability | Local (connects to Remote) |
 | `cleanup_desi_projects.py` | Removes old projects/venvs | Maintenance |
+
+### 🚇 Reverse SSH Tunnel Mode (Accessing Internal GPUs)
+
+To allow external access to the internal "Desi" cluster (e.g., to use its GPUs), you can set up a reverse SSH tunnel. This creates a persistent connection from the internal node to an external bridge server.
+
+#### Prerequisites for Tunnel
+* `autossh` installed on the node.
+* A process manager like `pm2` is recommended to keep the tunnel running.
+
+#### Configuration
+You must define the following environment variables (e.g., in your `.env` file or exported in your shell):
+
+* `SERVER_SSH`: The hostname or IP address of your external bridge server.
+* `SERVER_PORT`: The remote port on the bridge server that will be forwarded to the node's local SSH port (22).
+* `SERVER_USERNAME`: The username used to authenticate on the bridge server.
+
+#### Usage with PM2
+
+```bash
+export SERVER_SSH="bridge.example.com"
+export SERVER_PORT="12345"
+export SERVER_USERNAME="bridgeuser"
+
+pm2 start scripts/setup_reverse_tunnel.sh --name "desi-tunnel"
+```
 
 # Roadmap
 

--- a/scripts/setup_reverse_tunnel.sh
+++ b/scripts/setup_reverse_tunnel.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# ====================================================================
+# SLURM_RAY - Reverse SSH Tunnel Setup
+# ====================================================================
+# This script establishes a reverse SSH tunnel using autossh.
+# It is designed to run in the foreground to be easily managed by PM2.
+#
+# Requirements: autossh
+# Run with PM2: pm2 start scripts/setup_reverse_tunnel.sh --name "desi-tunnel"
+# ====================================================================
+
+# Check required environment variables
+if [ -z "$SERVER_SSH" ] || [ -z "$SERVER_PORT" ] || [ -z "$SERVER_USERNAME" ]; then
+    echo "ERROR: Missing required environment variables."
+    echo "Please ensure SERVER_SSH, SERVER_PORT, and SERVER_USERNAME are set."
+    echo ""
+    echo "Example:"
+    echo "  export SERVER_SSH=my-bridge-server.com"
+    echo "  export SERVER_PORT=12345"
+    echo "  export SERVER_USERNAME=bridgeuser"
+    exit 1
+fi
+
+echo "Starting Reverse SSH Tunnel..."
+echo "Target: $SERVER_USERNAME@$SERVER_SSH"
+echo "Remote Port: $SERVER_PORT -> Local Port: 22"
+
+# AUTOSSH_GATETIME=0 ensures autossh keeps retrying even if the first connection fails
+export AUTOSSH_GATETIME=0
+
+# Execute autossh
+# -M 0: Disable autossh monitoring port, rely on SSH ServerAliveInterval
+# -N: Do not execute a remote command
+# -o ServerAliveInterval=30: Send keep-alive packets every 30 seconds
+# -o ServerAliveCountMax=3: Disconnect after 3 missed keep-alive packets
+# -o ExitOnForwardFailure=yes: Exit if port forwarding fails, allowing autossh to restart it
+# -R: Reverse port forwarding
+exec autossh -M 0 -N \
+    -o "ServerAliveInterval 30" \
+    -o "ServerAliveCountMax 3" \
+    -o "ExitOnForwardFailure yes" \
+    -R "${SERVER_PORT}:localhost:22" \
+    "${SERVER_USERNAME}@${SERVER_SSH}"


### PR DESCRIPTION
Implémentation d'un tunnel SSH inversé pour accéder aux GPUs du cluster interne "Desi".

### Ce qui a été fait
1. **Création du script `scripts/setup_reverse_tunnel.sh`** :
   - Utilise `autossh` pour maintenir une connexion résiliente.
   - Configure les options SSH et autossh pour une fermeture sécurisée en cas de problème de connexion (`ServerAliveInterval`, `ExitOnForwardFailure=yes`).
   - S'exécute en avant-plan (via `exec`) pour être pris en charge et géré efficacement par le gestionnaire de processus `pm2`.
   - Vérifie la présence des variables d'environnement nécessaires (`SERVER_SSH`, `SERVER_PORT`, `SERVER_USERNAME`).

2. **Mise à jour de `README.md`** :
   - Ajout du script dans la liste des utilitaires.
   - Ajout d'une sous-section `Reverse SSH Tunnel Mode (Accessing Internal GPUs)` détaillant les prérequis, la configuration requise et comment lancer le service avec `pm2`.

---
*PR created automatically by Jules for task [1882225478075167423](https://jules.google.com/task/1882225478075167423) started by @hjamet*