### PR TITLE
feat: Configure Desi cluster connection via inverse SSH tunnel

### DIFF
--- a/slurmray/RayLauncher.py
+++ b/slurmray/RayLauncher.py
@@ -102,6 +102,7 @@ class Cluster:
         server_ssh: str = None,  # Auto-detected from cluster parameter
         server_username: str = None,
         server_password: str = None,
+        server_port: int = 22,
         log_file: str = ".slogs/Cluster.log",
         cluster: str = "curnagl",  # 'curnagl', 'desi', 'local', or custom IP/hostname
         force_reinstall_venv: bool = False,
@@ -127,6 +128,7 @@ class Cluster:
             server_ssh (str, optional): If `server_run` is set to true, the address of the server to use. Auto-detected from `cluster` parameter if not provided. Defaults to None (auto-detected).
             server_username (str, optional): If `server_run` is set to true, the username with which you wish to connect. Credentials are automatically loaded from a `.env` file (CURNAGL_USERNAME for Curnagl/custom IP, DESI_USERNAME for Desi) if available. Priority: environment variables → explicit parameter → default ("hjamet" for Curnagl/custom IP, "henri" for Desi).
             server_password (str, optional): If `server_run` is set to true, the password of the user to connect to the server. Credentials are automatically loaded from a `.env` file (CURNAGL_PASSWORD for Curnagl/custom IP, DESI_PASSWORD for Desi) if available. Priority: explicit parameter → environment variables → interactive prompt. CAUTION: never write your password in the code. Defaults to None.
+            server_port (int, optional): The SSH port to connect to. Defaults to 22. Set to 2222 for Desi.
             log_file (str, optional): Path to the log file. Defaults to ".slogs/Cluster.log".
             cluster (str, optional): Cluster/server to use: 'curnagl' (default, Slurm cluster), 'desi' (ISIPOL09/Desi server), 'local' (local execution), or a custom IP/hostname (for custom Slurm clusters). Defaults to "curnagl".
             force_reinstall_venv (bool, optional): Force complete removal and recreation of virtual environment on remote server/cluster. This will delete the existing venv and reinstall all packages from requirements.txt. Use this if the venv is corrupted or you need a clean installation. Defaults to False.
@@ -253,7 +255,8 @@ class Cluster:
         # Auto-detect server_ssh from cluster parameter if not provided
         if self.server_run and server_ssh is None:
             if cluster_lower == "desi":
-                self.server_ssh = "130.223.73.209"
+                self.server_ssh = "178.104.173.231"
+                server_port = server_port if server_port != 22 else 2222
             elif cluster_lower == "curnagl":
                 self.server_ssh = "curnagl.dcsr.unil.ch"
             elif is_custom_ip:
@@ -264,6 +267,10 @@ class Cluster:
                 self.server_ssh = "curnagl.dcsr.unil.ch"
         else:
             self.server_ssh = server_ssh or "curnagl.dcsr.unil.ch"
+            if cluster_lower == "desi":
+                server_port = server_port if server_port != 22 else 2222
+
+        self.server_port = server_port
 
         self.log_file = log_file
         self.force_reinstall_venv = force_reinstall_venv

--- a/slurmray/backend/desi.py
+++ b/slurmray/backend/desi.py
@@ -343,6 +343,7 @@ class DesiBackend(RemoteMixin):
                                 ssh_host=self.launcher.server_ssh,
                                 ssh_username=self.launcher.server_username,
                                 ssh_password=self.launcher.server_password,
+                                ssh_port=getattr(self.launcher, 'server_port', 22),
                                 remote_host="127.0.0.1",
                                 local_port=0, # Dynamic port to avoid contention
                                 remote_port=remote_port,

--- a/slurmray/backend/remote.py
+++ b/slurmray/backend/remote.py
@@ -56,6 +56,7 @@ class RemoteMixin(ClusterBackend):
                     hostname=self.launcher.server_ssh,
                     username=self.launcher.server_username,
                     password=self.launcher.server_password,
+                    port=getattr(self.launcher, 'server_port', 22),
                     banner_timeout=30, # Increased safety against hanging
                     auth_timeout=30,
                 )

--- a/slurmray/utils.py
+++ b/slurmray/utils.py
@@ -204,6 +204,7 @@ class SSHTunnel:
         local_port: int = 8888,
         remote_port: int = 8888,
         logger: logging.Logger = None,
+        ssh_port: int = 22,
     ):
         """Initialize SSH tunnel
 
@@ -215,6 +216,7 @@ class SSHTunnel:
             local_port: Local port to bind (default: 8888)
             remote_port: Remote port to forward (default: 8888)
             logger: Optional logger
+            ssh_port: SSH server port
         """
         self.ssh_host = ssh_host
         self.ssh_username = ssh_username
@@ -222,6 +224,7 @@ class SSHTunnel:
         self.remote_host = remote_host
         self.local_port = local_port
         self.remote_port = remote_port
+        self.ssh_port = ssh_port
         self.ssh_client = None
         self.forward_server = None
         self.logger = logger
@@ -235,6 +238,7 @@ class SSHTunnel:
                 hostname=self.ssh_host,
                 username=self.ssh_username,
                 password=self.ssh_password,
+                port=self.ssh_port,
             )
 
             # Create local port forwarding using socket server

--- a/validation_report.md
+++ b/validation_report.md
@@ -1,0 +1,75 @@
+# Rapport de validation : Architecture de connexion au cluster Desi via tunnel SSH inversé
+
+## 1. Objectifs
+
+La mission consistait à valider exclusivement l'architecture de connexion au cluster Desi via un tunnel SSH inversé (`178.104.173.231:2222`), à vérifier le fonctionnement de la configuration `SLURM_RAY` avec les identifiants fournis, et à prouver que le tunnel et les fonctionnalités fonctionnent sans mécanisme de fallback.
+
+## 2. Modifications effectuées
+
+- Modification du fichier `slurmray/RayLauncher.py` pour définir l'adresse SSH de Desi sur `178.104.173.231` (au lieu de `130.223.73.209`).
+- Ajout du support de port SSH personnalisé dans `slurmray/RayLauncher.py` et `slurmray/backend/remote.py`, en réglant la valeur par défaut pour Desi à `2222`.
+- Transmission de l'argument `ssh_port` dans la classe `SSHTunnel` pour s'assurer que la création du tunnel SSH pour le dashboard utilise le bon port.
+- Création et configuration d'un fichier `.env` avec les variables `DESI_USERNAME` et `DESI_PASSWORD` selon les instructions.
+
+## 3. Script de validation (`test_desi.py`)
+
+Un script a été conçu pour interroger les ressources matérielles distantes (via `nvidia-smi`) en utilisant `SLURM_RAY` :
+
+```python
+import os
+from slurmray import Cluster
+
+def test_desi_connection():
+    import subprocess
+    # Run a simple nvidia-smi to check GPU access
+    try:
+        result = subprocess.run(["nvidia-smi"], capture_output=True, text=True, check=True)
+        return {"status": "success", "output": result.stdout}
+    except Exception as e:
+        return {"status": "error", "error": str(e)}
+
+if __name__ == "__main__":
+    launcher = Cluster(
+        cluster="desi",
+        server_run=True,
+        num_gpus=1,
+    )
+    result = launcher(test_desi_connection)
+    print("Execution Result:", result)
+    if result["status"] == "success" and "NVIDIA-SMI" in result["output"]:
+        print("\n✅ Validated connection to Desi via SSH tunnel, Ray execution, and GPU access.")
+    else:
+        print("\n❌ Failed to validate Desi execution properly.")
+```
+
+## 4. Résultats et logs d'exécution
+
+Lors de l'exécution locale `poetry run python test_desi.py`, `SLURM_RAY` a pu se connecter au port 2222, lancer la tâche sur le cluster Desi, capturer la sortie et créer un tunnel SSH local vers le Dashboard Ray distant.
+
+**Logs de console complets:**
+```text
+✅ Using existing virtual environment
+✅ All dependencies already installed (requirements.txt is empty)
+🔒 Acquiring Smart Lock and starting job...
+🔒 Requesting resources: 4 CPU, 20 GB RAM, 1 GPU
+✅ Resources acquired immediately! (PID 3770019). CPU: 4, RAM: 20GB, GPUs: 1
+🔧 Set CUDA_VISIBLE_DEVICES=0
+🔧 Dynamic Dashboard Port: 54277
+🎉 Dashboard forwarded and available here : http://localhost:41623
+🔄 SlurmRay: Patching multiprocessing.Pool with Ray (proxy module)...
+   ✅ multiprocessing.Pool patched with Ray (all other attrs preserved)
+   ✅ torch.multiprocessing patched
+✅ Loaded function from dill pickle.
+Result written to /home/henri/slurmray-server/app/result.pkl
+Execution Result: {'status': 'success', 'output': 'Sat Apr 11 11:31:59 2026       \n+---------------------------------------------------------------------------------------+\n| NVIDIA-SMI 535.261.03             Driver Version: 535.261.03   CUDA Version: 12.2     |\n...
+|   0  NVIDIA GeForce RTX 3090        On  | 00000000:23:00.0 Off |                  N/A |\n|  0%   37C    P8              24W / 350W |     10MiB / 24576MiB |      0%      Default |\n...
+
+✅ Validated connection to Desi via SSH tunnel, Ray execution, and GPU access.
+```
+
+## 5. Conclusion
+
+L'accès au cluster Desi via le tunnel SSH inversé 178.104.173.231:2222 fonctionne de manière transparente et performante.
+- L'infrastructure `SLURM_RAY` soumet avec succès des tâches au GPU (`NVIDIA GeForce RTX 3090`).
+- Le tableau de bord et les résultats sont correctement acheminés.
+- Il n'y a pas eu besoin de contournement (fallback) complexe ; tout s'opère via les connexions SSH formelles de base modifiées pour prendre en charge le port 2222.


### PR DESCRIPTION
This patch finalizes the configuration to access the Desi cluster exclusively through a stable inverse SSH tunnel (`178.104.173.231:2222`), deprecating the old direct connection address (`130.223.73.209`).

It integrates `server_port` capability deep into the `SSHTunnel` and `paramiko` backend so that not only the launch command but also dashboard forwarding succeeds. The validation script confirmed that hardware (GPU via `nvidia-smi`) is fully accessible, as documented in the generated `validation_report.md`. No test files containing explicit credentials were left over.

---
*PR created automatically by Jules for task [2530406258125058924](https://jules.google.com/task/2530406258125058924) started by @hjamet*